### PR TITLE
chore: upgrade faker deprecations

### DIFF
--- a/packages/milliejs-jest-utils/src/mocks/entity.ts
+++ b/packages/milliejs-jest-utils/src/mocks/entity.ts
@@ -5,7 +5,7 @@ import { makeMockResource } from "./resource"
 export const makeMockEntity = <R extends Resource = Resource>(
   partial?: Partial<Entity<R>>,
 ): Entity<R | Resource> => ({
-  id: faker.datatype.uuid(),
+  id: faker.string.uuid(),
   resource: makeMockResource(),
   data: {},
   ...partial,

--- a/packages/milliejs-jest-utils/tests/unit/mock/entity.test.ts
+++ b/packages/milliejs-jest-utils/tests/unit/mock/entity.test.ts
@@ -9,7 +9,7 @@ describe("mocks/entity.ts", () => {
     describe("[id]", () => {
       describe("when an override is provided", () => {
         it("accepts the id override", () => {
-          const id = faker.datatype.uuid()
+          const id = faker.string.uuid()
 
           expect(makeMockEntity({ id })).toHaveProperty("id", id)
         })

--- a/packages/milliejs-jest-utils/tests/unit/mock/resource.test.ts
+++ b/packages/milliejs-jest-utils/tests/unit/mock/resource.test.ts
@@ -6,7 +6,7 @@ describe("mocks/resource.ts", () => {
     describe("[id]", () => {
       describe("when an override is provided", () => {
         it("accepts the id override", () => {
-          const id = faker.datatype.uuid()
+          const id = faker.string.uuid()
 
           expect(makeMockResource({ id })).toHaveProperty("id", id)
         })


### PR DESCRIPTION
## Summary

faker is reporting a deprecation for `faker.datatype.uuid` to `faker.string.uuid`

## Test plan

existing tests will cover this
