### PR TITLE
chore: setup release-please to start managing package versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: "Release Please"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action
+          bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
+          separate-pull-requests: true


### PR DESCRIPTION
## Summary

Use the initial workflow to start managing versions, and then drive release process down the road.
