### PR TITLE
ci: restore unplugged prettier in job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
+      - name: Restore yarn unplugged package cache
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        id: yarn-unplugged-package-cache-restore
+        with:
+          key: ${{ runner.os }}-yarn-unplugged-${{ github.ref_name }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-unplugged-${{ github.ref_name }}-
+            ${{ runner.os }}-yarn-unplugged-${{ github.head_ref }}-
+            ${{ runner.os }}-yarn-unplugged-main
+          path: |
+            ./.yarn/unplugged
       - name: Restore Build cache
         id: cache-build-restore
         uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16",
 
-
     // build entire project tree
     "composite": true,
     // output build cache


### PR DESCRIPTION
## Summary

The lint-prettier job needs unplugged prettier to execute

## Test plan

CI